### PR TITLE
use monadic bind rather than convoluted function arg

### DIFF
--- a/lib/Api/Controllers/User.hs
+++ b/lib/Api/Controllers/User.hs
@@ -67,8 +67,8 @@ verifyEdit = do
 loginFromHeader :: ApiActionM s (Maybe User)
 loginFromHeader = do
     authToken <- header "Authorization"
-    uid <- reqParam "user_id"
     case LT.words <$> authToken of
-      Just ["Token", token] ->
+      Just ["Token", token] -> do
+        uid <- reqParam "user_id"
         query $ User.findByLogin . Login uid . UserToken $ LT.toStrict token
       _ -> raise MissingAuthToken

--- a/lib/Api/Controllers/User.hs
+++ b/lib/Api/Controllers/User.hs
@@ -1,4 +1,9 @@
-module Api.Controllers.User where
+module Api.Controllers.User
+( authenticate
+, create
+, unverifiedEdit
+, verifyEdit
+) where
 
 import Api.Types.Fields (UserToken (..))
 import Api.Types.Server (ApiActionM, ApiException (..), mailer)
@@ -19,6 +24,13 @@ import Api.Helpers.Controller
 import Api.Types.Resource
 import Api.Types.PendingUserResource
 import Api.Types.User
+
+authenticate :: ApiActionM s User
+authenticate = do
+    foundUser <- loginFromHeader
+    case foundUser of
+      Just user -> return user
+      _ -> raise UnauthorizedUser
 
 -- only used to register a new device
 
@@ -50,14 +62,13 @@ verifyEdit = do
     uid   = pend_userId . pend_fields
     email = pend_resourceEmail . pend_fields
 
-authenticate :: (User -> ApiActionM s ()) -> ApiActionM s ()
-authenticate routeFor = do
-  authToken <- header "Authorization"
-  case LT.words <$> authToken of
-    Just ["Token", token] -> do
-      uid  <- reqParam "user_id"
-      user <- query $ User.findByLogin . Login uid . UserToken $ LT.toStrict token
-      case user of
-        Just u -> routeFor u
-        _      -> raise UnauthorizedUser
-    _ -> raise MissingAuthToken
+-- private functions
+
+loginFromHeader :: ApiActionM s (Maybe User)
+loginFromHeader = do
+    authToken <- header "Authorization"
+    uid <- reqParam "user_id"
+    case LT.words <$> authToken of
+      Just ["Token", token] ->
+        query $ User.findByLogin . Login uid . UserToken $ LT.toStrict token
+      _ -> raise MissingAuthToken

--- a/lib/Api/Routes.hs
+++ b/lib/Api/Routes.hs
@@ -16,10 +16,10 @@ routes = defaultHandler fallback >> do
     get  "/verify/:uuid"     User.verifyEdit
 
     post "/users"            User.create
-    post "/users/:user_id" $ User.authenticate User.unverifiedEdit
+    post "/users/:user_id" $ User.authenticate >>= User.unverifiedEdit
 
-    get  "/resource"       $ User.authenticate Resource.show
-    post "/resource"       $ User.authenticate Resource.edit
+    get  "/resource"       $ User.authenticate >>= Resource.show
+    post "/resource"       $ User.authenticate >>= Resource.edit
 
 fallback :: ApiException -> ApiActionM s ()
 fallback err = case err of


### PR DESCRIPTION
For some reason, I originally implemented user authentication via passing a
controller function to the `authenticate` function, when the user really should
be supplied via monadic bind (which is what happens anyways, the original
function just obscured it). This has been corrected for readability and
ease-of-use.
